### PR TITLE
Allow a symbol for :except and :only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ You can also call `.as_json` method with `:except` and `:only` options.
 Blog.new.as_json(only: [:id, :username])
 #=> { "id" => 1, "username" => "alice" }
 
-Blog.new.as_json(except: [:username])
+Blog.new.as_json(except: :username)
 #=> { "id" => 1, "title" => "wonderland" }
 ```

--- a/lib/json/encodable.rb
+++ b/lib/json/encodable.rb
@@ -58,8 +58,8 @@ module JSON
 
     # @note All Time values will be encoded in ISO 8601 format
     # @param options [Hash] Options for .property_names method
-    # @option options [Array<Symbol>] :except Property names to exclude properties
-    # @option options [Array<Symbol>] :only Property names to filter properties
+    # @option options [Symbol, Array<Symbol>] :except Property names to exclude properties
+    # @option options [Symbol, Array<Symbol>] :only Property names to filter properties
     # @return [Hash{Symbol => Object}] Properties as a key-value pairs Hash
     # @example
     #   {
@@ -70,8 +70,8 @@ module JSON
     #   }
     def properties(options = {})
       names = self.class.property_names
-      names = names - options[:except] if options[:except]
-      names = names & options[:only] if options[:only]
+      names = names - Array(options[:except]) if options[:except]
+      names = names & Array(options[:only]) if options[:only]
       names.inject({}) do |hash, property_name|
         key = property_name
         value = send(property_name)

--- a/spec/json/encodable_spec.rb
+++ b/spec/json/encodable_spec.rb
@@ -51,27 +51,31 @@ describe JSON::Encodable do
       end
     end
 
-    context "with :except option" do
-      before do
-        options[:except] = [:id]
-      end
+    [:id, [:id]].each do |except_value|
+      context "when a #{except_value.class.name.downcase} is given as :except option" do
+        before do
+          options[:except] = except_value
+        end
 
-      it "excludes those properties" do
-        instance.should_not_receive(:id)
-        should be_json_as(
-          title: "wonderland",
-          username: "alice",
-        )
+        it "excludes those properties" do
+          instance.should_not_receive(:id)
+          should be_json_as(
+            title: "wonderland",
+            username: "alice",
+          )
+        end
       end
     end
 
-    context "with :only option" do
-      before do
-        options[:only] = [:id]
-      end
+    [:id, [:id]].each do |only_value|
+      context "when a #{only_value.class.name.downcase} is given as :only option" do
+        before do
+          options[:only] = only_value
+        end
 
-      it "excludes those properties" do
-        should be_json_as(id: 1)
+        it "excludes those properties" do
+          should be_json_as(id: 1)
+        end
       end
     end
   end


### PR DESCRIPTION
Like [Rails' one](https://github.com/rails/rails/blob/v4.2.0/activerecord/lib/active_record/serialization.rb#L14).
